### PR TITLE
Remove .JuliaFormatter.toml

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-yas_style_nesting=false
-ignore = ["docs"]


### PR DESCRIPTION
As the code is now formatted with Runic.jl, .JuliaFormatter.toml is not needed anymore.